### PR TITLE
Eliminates dependence on boost::format library, Fixed minor bugs.

### DIFF
--- a/xz80.cpp
+++ b/xz80.cpp
@@ -4,6 +4,18 @@ class Gen : public Xz80::Generator {
  public:
   Gen() : Xz80::Generator(0x0100) {}
   void testcase(void) {
+    // 内部処理用クラスのテスト
+    Xz80::Formatter::Formatter f("漢字ir,r,r,r,r,r,r,r,r,");
+    std::cout << (f % ";" % A % C() % HL % HL() % BC() % DE() % IX() % SP() % IY(0)).str() << std::endl;
+
+    Xz80::Formatter::Formatter g("idxdx");
+    std::cout << (g % ";" % 42 % 42 % -1 % -1).str() << std::endl;
+
+    Xz80::Formatter::Formatter h("ib,w");
+    std::initializer_list<uint8_t> bs{0xde, 0xad, 0xbe, 0xef};
+    std::initializer_list<uint16_t> ws{0xdead, 0xbeef, 0xcafe, 0xbabe};
+    std::cout << (h % ";" % bs % ws).str() << std::endl;
+
     l("HEAD");
     ld(A, B);
     ld(C, 64);
@@ -27,7 +39,7 @@ class Gen : public Xz80::Generator {
     ld(A, mem(0xbeef));
     ld(BC(), A);
     ld(DE(), A);
-    ld(A, mem(0xcafe));
+    ld(mem(0xcafe), A);
     ld(A, I);
     ld(I, A);
     ld(A, R);
@@ -365,7 +377,6 @@ class Gen : public Xz80::Generator {
     cp(IX(0));
     cp(IY(-42));
     // ----
-    return;
     l("JP0");
     jp(0xbeef);
     l("JP1");
@@ -488,6 +499,7 @@ class Gen : public Xz80::Generator {
     dw({"LABEL1", "LABEL2", "LABEL3"});
     db({0xcd, 0xf7, 0xf8});
     dw({0x1234, 0x5678, 0xcc33});
+    db("Hello!\r\n");
     // ----
   }
 };

--- a/xz80.hpp
+++ b/xz80.hpp
@@ -99,6 +99,9 @@ struct IndenexReg16AddrOffset {
   const int8_t m_offset;
   IndenexReg16AddrOffset(const IndexReg16& reg16, int8_t offset)
       : m_reg(reg16), m_offset(offset) {}
+  uint8_t getOffset(void) const {
+    return static_cast<uint8_t>(m_offset);
+  }
 };
 
 struct IndenexReg16Addr {
@@ -955,7 +958,7 @@ class Generator {
   void ld(const BasicReg8& r, const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r,r") % "LD" % r % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b01, r, F),
-            static_cast<uint8_t>(ireg16_offset.m_offset)});
+            ireg16_offset.getOffset()});
   }
 
   /// LD (HL), r | mem[HL] <- reg8
@@ -968,7 +971,7 @@ class Generator {
   void ld(const IndenexReg16AddrOffset& ireg16_offset, const BasicReg8& r) {
     append(Fmt("i r,r") % "LD" % ireg16_offset % r,  //
            {ireg16_offset.m_reg.m_prefix, build(0b01, F, r),
-            static_cast<uint8_t>(ireg16_offset.m_offset)});
+            ireg16_offset.getOffset()});
   }
 
   /// LD (HL), r | mem[HL] <- constant8
@@ -981,7 +984,7 @@ class Generator {
   void ld(const IndenexReg16AddrOffset& ireg16_offset, uint8_t n) {
     append(Fmt("i r,x") % "LD" % ireg16_offset % n,  //
            {ireg16_offset.m_reg.m_prefix, build(0b00, F, F),
-            static_cast<uint8_t>(ireg16_offset.m_offset), n});
+            ireg16_offset.getOffset(), n});
   }
 
   /// LD A, (BC or DE) | A <- mem[BC or DE]
@@ -1275,7 +1278,7 @@ class Generator {
   void rlc(const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r") % "RLC" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(ireg16_offset.m_offset), 0b0000'0110});
+            ireg16_offset.getOffset(), 0b0000'0110});
   }
 
   /// RL r |
@@ -1294,7 +1297,7 @@ class Generator {
   void rl(const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r") % "RL" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(ireg16_offset.m_offset), 0b0001'0110});
+            ireg16_offset.getOffset(), 0b0001'0110});
   }
 
   // ---------------------------------
@@ -1328,7 +1331,7 @@ class Generator {
   void rrc(const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r") % "RRC" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(ireg16_offset.m_offset), build(0b00, C, F)});
+            ireg16_offset.getOffset(), build(0b00, C, F)});
   }
 
   /// RR r |
@@ -1347,7 +1350,7 @@ class Generator {
   void rr(const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r") % "RR" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(ireg16_offset.m_offset), build(0b00, E, F)});
+            ireg16_offset.getOffset(), build(0b00, E, F)});
   }
 
   // ---------------------------------
@@ -1369,7 +1372,7 @@ class Generator {
   void sla(const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r") % "SLA" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(ireg16_offset.m_offset), build(0b00, H, F)});
+            ireg16_offset.getOffset(), build(0b00, H, F)});
   }
 
   // ---------------------------------
@@ -1391,7 +1394,7 @@ class Generator {
   void sra(const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r") % "SRA" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(ireg16_offset.m_offset), build(0b00, L, F)});
+            ireg16_offset.getOffset(), build(0b00, L, F)});
   }
 
   /// SRL r |
@@ -1409,7 +1412,7 @@ class Generator {
   void srl(const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r") % "SRL" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(ireg16_offset.m_offset), build(0b00, A, F)});
+            ireg16_offset.getOffset(), build(0b00, A, F)});
   }
 
   // =========================================================================
@@ -1440,7 +1443,7 @@ class Generator {
   void add(const RegA& a, const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r,r") % "ADD" % a % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, B, F),
-            static_cast<uint8_t>(ireg16_offset.m_offset)});
+            ireg16_offset.getOffset()});
   }
 
   /// ADC A, r | A <- A + reg8 + carry
@@ -1465,7 +1468,7 @@ class Generator {
   void adc(const RegA& a, const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r,r") % "ADC" % a % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, C, F),
-            static_cast<uint8_t>(ireg16_offset.m_offset)});
+            ireg16_offset.getOffset()});
   }
 
   /// INC r | reg8 <- reg8 + 1
@@ -1484,7 +1487,7 @@ class Generator {
   void inc(const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r") % "INC" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b00, F, H),
-            static_cast<uint8_t>(ireg16_offset.m_offset)});
+            ireg16_offset.getOffset()});
   }
 
   // ---------------------------------
@@ -1512,7 +1515,7 @@ class Generator {
   void sub(const RegA& a, const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r,r") % "SUB" % a % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, D, F),
-            static_cast<uint8_t>(ireg16_offset.m_offset)});
+            ireg16_offset.getOffset()});
   }
 
   /// SBC A, r | A <- A - reg8 - carry
@@ -1537,7 +1540,7 @@ class Generator {
   void sbc(const RegA& a, const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r,r") % "SBC" % a % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, E, F),
-            static_cast<uint8_t>(ireg16_offset.m_offset)});
+            ireg16_offset.getOffset()});
   }
 
   /// DEC r | reg8 <- reg8 - 1
@@ -1556,7 +1559,7 @@ class Generator {
   void dec(const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r") % "DEC" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b00, F, L),
-            static_cast<uint8_t>(ireg16_offset.m_offset)});
+            ireg16_offset.getOffset()});
   }
 
   // =========================================================================
@@ -1665,7 +1668,7 @@ class Generator {
   void and (const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r") % "AND" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, H, F),
-            static_cast<uint8_t>(ireg16_offset.m_offset)});
+            ireg16_offset.getOffset()});
   }
 
   /// OR r | A <- A | reg8
@@ -1690,7 +1693,7 @@ class Generator {
   void or (const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r") % "OR" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, F, F),
-            static_cast<uint8_t>(ireg16_offset.m_offset)});
+            ireg16_offset.getOffset()});
   }
 
 #define XZ80_XOR xor
@@ -1717,7 +1720,7 @@ class Generator {
   void XZ80_XOR(const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r") % "XOR" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, L, F),
-            static_cast<uint8_t>(ireg16_offset.m_offset)});
+            ireg16_offset.getOffset()});
   }
 
   /// CPL | A <- ~A
@@ -1778,7 +1781,7 @@ class Generator {
     }
     append(Fmt("i d,r") % "BIT" % b % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(ireg16_offset.m_offset),
+            ireg16_offset.getOffset(),
             static_cast<uint8_t>(0b0100'0000 | b << 3 | 0b110)});
   }
 
@@ -1813,7 +1816,7 @@ class Generator {
     }
     append(Fmt("i d,r") % "SET" % b % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(ireg16_offset.m_offset),
+            ireg16_offset.getOffset(),
             static_cast<uint8_t>(0b1100'0000 | b << 3 | 0b110)});
   }
 
@@ -1848,7 +1851,7 @@ class Generator {
     }
     append(Fmt("i d,r") % "RES" % b % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(ireg16_offset.m_offset),
+            ireg16_offset.getOffset(),
             static_cast<uint8_t>(0b1000'0000 | b << 3 | 0b110)});
   }
 
@@ -1901,7 +1904,7 @@ class Generator {
   void cp(const IndenexReg16AddrOffset& ireg16_offset) {
     append(Fmt("i r") % "CP" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1011'1110,
-            static_cast<uint8_t>(ireg16_offset.m_offset)});
+            ireg16_offset.getOffset()});
   }
 
   // =========================================================================

--- a/xz80.hpp
+++ b/xz80.hpp
@@ -2,16 +2,14 @@
 #error "use -fno-operator-names"
 #endif
 
-#include <boost/format.hpp>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <iostream>
 #include <map>
 #include <stdexcept>
 #include <string>
 #include <vector>
-
-#define XZ80_FINAL(expr) ([&](void) -> const auto { expr }())
 
 namespace Xz80 {
 // =======================================================================
@@ -154,17 +152,9 @@ struct IndexReg16 : public Reg16 {
 };
 
 struct IoAddr {
- private:
-  static std::string make(uint8_t n) {
-    return (boost::format("(0%xh)") % static_cast<int>(n)).str();
-  }
-
- public:
   const uint8_t addr;
-  const std::string str;
   explicit IoAddr(uint8_t io_addr)
-      : addr(io_addr),  //
-        str(make(io_addr)) {}
+      : addr(io_addr) {}
 };
 
 struct MemAddr {
@@ -183,6 +173,402 @@ struct MemAddr {
 
   bool isLabel(void) const { return !label.empty(); }
 };
+
+// =======================================================================
+// ニーモニックフォーマッター
+
+namespace Formatter {
+enum Type {
+  T_End = '\0',
+  T_Insn = 'i',        // str Insn.
+  T_Label = 'l',       // str Label
+  T_Symbol = 's',      // str Symbol
+  T_Indirect = 'I',    // str/word (nn) Indirect
+  T_Reg = 'r',         // reg
+  T_Condition = 'c',   // str condition
+  T_Comma = ',',       // no-arg
+  T_Dash = '\'',       // no-arg
+  T_Dec = 'd',         // decimal number
+  T_Hex = 'x',         // hex number
+  T_AddrOffset = 'o',  // $+/-d number
+  T_Bytes = 'b',       // bytes
+  T_Words = 'w',       // words
+  T_Text = 't',        // str
+  T_Unknown = '?',     // ignore
+};
+
+class Formatter {
+  const char* m_format;
+  const char* m_p;
+  std::string m_buffer;
+
+  Type nextType(void) const {
+    // return static_cast<Type>(*m_p);
+    switch (*m_p) {
+      case '\0':
+        return T_End;
+      case 'i':
+        return T_Insn;
+      case 'l':
+        return T_Label;
+      case 's':
+        return T_Symbol;
+      case 'I':
+        return T_Indirect;
+      case 'r':
+        return T_Reg;
+      case 'c':
+        return T_Condition;
+      case ',':
+        return T_Comma;
+      case '\'':
+        return T_Dash;
+      case 'd':
+        return T_Dec;
+      case 'x':
+        return T_Hex;
+      case 'o':
+        return T_AddrOffset;
+      case 'b':
+        return T_Bytes;
+      case 'w':
+        return T_Words;
+      case 't':
+        return T_Text;
+      default:
+        break;
+    }
+    return T_Unknown;
+  }
+
+  void reduceNoArg(void) {
+    while (true) {
+      switch (nextType()) {
+        case T_Comma:
+          ++m_p;
+          m_buffer.append(", ");
+          break;
+
+        case T_Dash:
+          ++m_p;
+          m_buffer.append("'");
+          break;
+
+        case T_Unknown:
+          ++m_p;
+          break;
+
+        default:
+          return;
+      }  // switch
+    }    // while
+  }
+
+ public:
+  Formatter(const char* format)
+      : m_format(format),
+        m_p(&m_format[0]),
+        m_buffer() {
+    reduceNoArg();
+  }
+
+  const std::string& str(void) const { return m_buffer; }
+
+  Formatter operator%(const std::string& str) {
+    return *this % str.c_str();
+  }
+
+  Formatter operator%(const char* str) {
+    switch (nextType()) {
+      case T_Insn:
+        ++m_p;
+        m_buffer.append("    ").append(str).append(" ");
+        break;
+
+      case T_Label:
+        ++m_p;
+        m_buffer.append(str).append(":");
+        break;
+
+      case T_Symbol:
+        ++m_p;
+        m_buffer.append(str);
+        break;
+
+      case T_Text: {
+        ++m_p;
+        std::string s;
+        bool outside = true;
+        for (const char* p = str; *p != '\0'; ++p) {
+          if (std::isprint(*p) && *p != '\'') {
+            if (outside) {
+              s.append(", '");
+              outside = false;
+            }
+            const char b[2] = {*p, 0};
+            s.append(b);
+          } else {
+            if (!outside) {
+              s.append("'");
+              outside = true;
+            }
+            char buf[8];
+            std::sprintf(buf, ", 0%xh", (0xff & *p));
+            s.append(buf);
+          }
+        }  // for
+        if (!outside) {
+          s.append("'");
+        }
+        if (s.empty()) {
+          s = ", ''";
+        }
+        m_buffer.append(s.begin() + 2, s.end());
+
+        break;
+      }
+
+      default:
+        throw std::invalid_argument("const char*不正な組み合わせ");
+        break;
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(const Reg8& r) {
+    switch (nextType()) {
+      case T_Reg:
+        ++m_p;
+        m_buffer.append(r.str);
+        break;
+      default:
+        throw std::invalid_argument("Reg8不正な組み合わせ");
+        break;
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(const RegCAddr& c) {
+    switch (nextType()) {
+      case T_Reg:
+        ++m_p;
+        m_buffer.append("(").append(c.m_reg.str).append(")");
+        break;
+      default:
+        throw std::invalid_argument("Reg8不正な組み合わせ");
+        break;
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(const Reg16& r) {
+    switch (nextType()) {
+      case T_Reg:
+        ++m_p;
+        m_buffer.append(r.str);
+        break;
+
+      default:
+        throw std::invalid_argument("Reg16不正な組み合わせ");
+        break;
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(const BasicReg16Addr& rp) {
+    if (nextType() == T_Reg) {
+      ++m_p;
+      m_buffer.append("(").append(rp.m_reg.str).append(")");
+    } else {
+      throw std::invalid_argument("BasicReg16Addr不正な組み合わせ");
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(const RegHLAddr& hl) {
+    if (nextType() == T_Reg) {
+      ++m_p;
+      m_buffer.append("(").append(hl.m_reg.str).append(")");
+    } else {
+      throw std::invalid_argument("RegHLAddr不正な組み合わせ");
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(const RegSPAddr& sp) {
+    if (nextType() == T_Reg) {
+      ++m_p;
+      m_buffer.append("(").append(sp.m_reg.str).append(")");
+    } else {
+      throw std::invalid_argument("RegSPAddr不正な組み合わせ");
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(const IndenexReg16AddrOffset& idx_offset) {
+    if (nextType() == T_Reg) {
+      ++m_p;
+      const int ofs = idx_offset.m_offset;
+      char buf[16];
+      if (ofs < 0) {
+        std::sprintf(buf, "-0%xh)", -ofs);
+      } else {
+        std::sprintf(buf, "+0%xh)", ofs);
+      }
+      m_buffer.append("(").append(idx_offset.m_reg.str).append(buf);
+    } else {
+      throw std::invalid_argument("IndenexReg16AddrOffset不正な組み合わせ");
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(const IndenexReg16Addr& idx) {
+    if (nextType() == T_Reg) {
+      ++m_p;
+      m_buffer.append("(").append(idx.m_reg.str).append(")");
+    } else {
+      throw std::invalid_argument("IndenexReg16Addr不正な組み合わせ");
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(const IoAddr& io) {
+    if (nextType() == T_Indirect) {
+      ++m_p;
+      char buf[8];
+      std::sprintf(buf, "(0%xh)", (0xff & io.addr));
+      m_buffer.append(buf);
+    } else {
+      throw std::invalid_argument("IoAddr不正な組み合わせ");
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(const CondBase& cc) {
+    if (nextType() == T_Condition) {
+      ++m_p;
+      m_buffer.append(cc.str);
+    } else {
+      throw std::invalid_argument("CondBase不正な組み合わせ");
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(int n) {
+    char buf[16];
+    switch (nextType()) {
+      case T_Dec:
+        ++m_p;
+        std::sprintf(buf, "%d", n);
+        m_buffer.append(buf);
+        break;
+
+      case T_Hex:
+        ++m_p;
+        std::sprintf(buf, "0%xh", n);
+        m_buffer.append(buf);
+        break;
+
+      case T_AddrOffset:
+        ++m_p;
+        std::sprintf(buf, "%+d", n);
+        m_buffer.append("$").append(buf);
+        break;
+
+      default:
+        throw std::invalid_argument("");
+        break;
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(const std::initializer_list<uint8_t>& bytes) {
+    if (nextType() == T_Bytes) {
+      ++m_p;
+      std::string s;
+      for (uint8_t b : bytes) {
+        char buf[8];
+        std::sprintf(buf, ", 0%xh", 0xff & b);
+        s.append(buf);
+      }
+      m_buffer.append(s.begin() + 2, s.end());
+    } else {
+      throw std::invalid_argument("");
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(const std::initializer_list<uint16_t>& words) {
+    if (nextType() == T_Words) {
+      ++m_p;
+      std::string s;
+      for (uint16_t w : words) {
+        char buf[12];
+        std::sprintf(buf, ", 0%xh", 0xffff & w);
+        s.append(buf);
+      }
+      m_buffer.append(s.begin() + 2, s.end());
+    } else {
+      throw std::invalid_argument("");
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+  Formatter operator%(const MemAddr& nn) {
+    if (nextType() == T_Indirect) {
+      ++m_p;
+      if (nn.isLabel()) {
+        m_buffer.append("(").append(nn.label).append(")");
+      } else {
+        char buf[16];
+        std::sprintf(buf, "(0%xh)", nn.addr);
+        m_buffer.append(buf);
+      }
+    } else {
+      throw std::invalid_argument("");
+    }
+    reduceNoArg();
+    return *this;
+  }
+
+#if 0
+  //テンプレ
+  Formatter operator%(const char* str) {
+    switch (nextType()) {
+      case T_End:
+      case T_Insn:
+      case T_Reg:
+      case T_Comma:
+      case T_Dec:
+      case T_Hex:
+      case T_Bytes:
+      case T_Words:
+      case T_Text:
+      default:
+        throw std::invalid_argument("");
+        break;
+    }
+    reduceNoArg();
+    return *this;
+  }
+#endif
+};
+
+}  // namespace Formatter
 
 // =======================================================================
 // コードジェネレータ
@@ -227,8 +613,9 @@ class Mnemonic {
     if (m_rel) {
       const int e = static_cast<int>(addr) - static_cast<int>(m_addr);
       if (e < -126 || 129 < e) {
-        throw std::out_of_range(
-            (boost::format("Label resolve e=%d:out of range") % e).str());
+        char buf[64];
+        std::sprintf(buf, "Label resolve e=%d:out of range", e);
+        throw std::out_of_range(buf);
       }
       m_bytes[m_offset] = static_cast<uint8_t>((e - 2) & 0xff);
     } else {
@@ -242,6 +629,7 @@ class Mnemonic {
 };
 
 class Generator {
+  typedef Formatter::Formatter Fmt;
   const uint16_t m_org;
   uint16_t m_curr;
   std::vector<Mnemonic> m_mnemonics;
@@ -315,25 +703,17 @@ class Generator {
     m_mnemonics.push_back(m);
   }
 
-  void append(const boost::basic_format<char>& mnemonic) {
+  void append(const Fmt& mnemonic) {
     Mnemonic m(m_curr, mnemonic.str(), std::vector<uint8_t>());
     m_mnemonics.push_back(m);
   }
 
-  void append(const boost::basic_format<char>& mnemonic,
+  void append(const Fmt& mnemonic,
               const std::vector<uint8_t>& bytes) {
     append(mnemonic.str(), bytes);
   }
-
-  void append(const std::string& mnemonic, const uint8_t bytes...) {
-    const std::vector<uint8_t> bs{bytes};
-    append(mnemonic, bs);
-  }
-
-  void append(const boost::basic_format<char>& mnemonic,
-              const uint8_t bytes...) {
-    const std::vector<uint8_t> bs{bytes};
-    append(mnemonic, bs);
+  void append(const Fmt& mnemonic, uint8_t byte) {
+    append(mnemonic.str(), std::vector<uint8_t>{byte});
   }
 
   /// アドレス解決用の情報を登録する
@@ -384,8 +764,10 @@ class Generator {
     std::printf("ORG 0100h\n");
     for (const auto& m : m_mnemonics) {
       std::string s;
+      char buf[8];
       for (const auto b : m.getBytes()) {
-        s += (boost::format("%02X ") % static_cast<int>(b)).str();
+        std::sprintf(buf, "%02x ", b);
+        s += buf;
       }
       std::printf("%-20s\t;%04Xh(%+d): %s\n",  //
                   m.getMnemonic().c_str(), m.getAddr(), m.getAddr() - m_org,
@@ -488,66 +870,52 @@ class Generator {
 
   /// DB byte | constant8
   void db(uint8_t byte) {
-    append(boost::format("DB 0%Xh") % static_cast<int>(byte),  //
+    append(Fmt("i b") % "DB" % std::initializer_list<uint8_t>{byte},  //
            byte);
   }
 
   /// DB byte | constant8 ...
   void db(std::initializer_list<uint8_t> bytes) {
-    std::string cmd;
-    for (const uint8_t b : bytes) {
-      cmd += (boost::format(", 0%xh") % static_cast<int>(b)).str();
-    }
-    cmd = std::string("DB ") + cmd.substr(2);
-    append(cmd, bytes);
+    append(Fmt("i b") % "DB" % bytes,  //
+           bytes);
   }
 
   /// DB byte | constant8 ...
   void db(const char* str) {
-    std::string cmd;
-    for (const char* p = str; *p != '\0'; ++p) {
-      const uint8_t b = *p;
-      cmd += (boost::format(", 0%xh") % static_cast<int>(b)).str();
-    }
-    cmd = std::string("DB ") + cmd.substr(2);
     const std::vector<uint8_t> bs(str, str + std::strlen(str));
-    append(cmd, bs);
+    append(Fmt("i t") % "DB" % str,  //
+           bs);
   }
 
   /// DW word | constant16
   void dw(uint16_t word) {
-    append(boost::format("DW 0%Xh") % word,  //
-           {
-               static_cast<uint8_t>(0xff & word),
-               static_cast<uint8_t>(0xff & (word >> 8)),
-           });
+    const MemAddr m(word);
+    append(Fmt("ix") % "DW" % word,  //
+           {m.l, m.h});
   }
 
   /// DB word | constant16 ...
   void dw(std::initializer_list<uint16_t> words) {
-    std::string cmd;
-    for (const uint16_t w : words) {
-      cmd += (boost::format(", 0%xh") % static_cast<int>(w)).str();
-    }
-    cmd = std::string("DW ") + cmd.substr(2);
     std::vector<uint8_t> bs;
     for (const uint16_t w : words) {
-      bs.push_back(w & 0xff);
-      bs.push_back(w >> 8);
+      const MemAddr m(w);
+      bs.push_back(m.l);
+      bs.push_back(m.h);
     }
-    append(cmd, bs);
+    append(Fmt("i w") % "DW" % words,  //
+           bs);
   }
 
   /// DB label | label ...
   void dw(std::string label) {
-    append(boost::format("DW %s") % label, {0x00, 0x00});
+    append(Fmt("i s") % "DW" % label, {0x00, 0x00});
     resolve(label.c_str(), 0);
   }
 
   /// DB label | label ...
   void dw(std::initializer_list<const std::string> labels) {
     for (const std::string& l : labels) {
-      append(boost::format("DW %s") % l, {0x00, 0x00});
+      append(Fmt("i s") % "DW" % l, {0x00, 0x00});
       resolve(l.c_str(), 0);
     }
   }
@@ -558,7 +926,7 @@ class Generator {
   /// Label
   uint16_t l(const char* label) {
     m_labelMap.insert(std::make_pair(std::string(label), m_curr));
-    append(boost::format("%s:") % label);
+    append(Fmt("l") % label);
     return m_curr;
   }
 
@@ -567,115 +935,106 @@ class Generator {
 
   /// LD r1, r2 | reg8 <- reg8
   void ld(const BasicReg8& r1, const BasicReg8& r2) {
-    append(boost::format("LD %s, %s") % r1.str % r2.str,  //
+    append(Fmt("i r,r") % "LD" % r1 % r2,  //
            build(0b01, r1, r2));
   }
 
   /// LD r, n | reg8 <- constant8
   void ld(const BasicReg8& r, uint8_t n) {
-    append(boost::format("LD %s, 0%xh") % r.str % static_cast<int>(n),  //
+    append(Fmt("i r,x") % "LD" % r % n,  //
            {build(0b00, r, F), n});
   }
 
   /// LD r, (HL) | reg8 <- mem[HL]
   void ld(const BasicReg8& r, const RegHLAddr& hl_addr) {
-    append(boost::format("LD %s, (HL)") % r.str,  //
+    append(Fmt("i r,r") % "LD" % r % hl_addr,  //
            build(0b01, r, F));
   }
 
   /// LD r,(indexreg16+offset) | reg8 <- mem[(IX or IY)+offset8]
   void ld(const BasicReg8& r, const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("LD %s, (%s%c0%xh)") % r.str %
-               ireg16_offset.m_reg.str % (offset < 0 ? '-' : '+') %
-               (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r,r") % "LD" % r % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b01, r, F),
-            static_cast<uint8_t>(offset)});
+            static_cast<uint8_t>(ireg16_offset.m_offset)});
   }
 
   /// LD (HL), r | mem[HL] <- reg8
   void ld(const RegHLAddr& hl_addr, const BasicReg8& r) {
-    append(boost::format("LD (HL), %s") % r.str,  //
+    append(Fmt("i r,r") % "LD" % hl_addr % r,  //
            build(0b01, F, r));
   }
 
   /// LD (indexreg16+offset), r |  mem[(IX or IY)+offset8] <- reg8
   void ld(const IndenexReg16AddrOffset& ireg16_offset, const BasicReg8& r) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("LD (%s%c0%xh), %s") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset) %
-               r.str,  //
+    append(Fmt("i r,r") % "LD" % ireg16_offset % r,  //
            {ireg16_offset.m_reg.m_prefix, build(0b01, F, r),
-            static_cast<uint8_t>(offset)});
+            static_cast<uint8_t>(ireg16_offset.m_offset)});
   }
 
   /// LD (HL), r | mem[HL] <- constant8
   void ld(const RegHLAddr& hl_addr, uint8_t n) {
-    append(boost::format("LD (HL), 0%xh") % static_cast<int>(n),  //
+    append(Fmt("i r,x") % "LD" % hl_addr % n,  //
            {build(0b00, F, F), n});
   }
 
-  /// LD (indexreg16+offset), r |  mem[(IX or IY)+offset8] <- constant8
+  /// LD (indexreg16+offset), n |  mem[(IX or IY)+offset8] <- constant8
   void ld(const IndenexReg16AddrOffset& ireg16_offset, uint8_t n) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("LD (%s%c0%xh), 0%xh") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset) %
-               static_cast<int>(n),  //
+    append(Fmt("i r,x") % "LD" % ireg16_offset % n,  //
            {ireg16_offset.m_reg.m_prefix, build(0b00, F, F),
-            static_cast<uint8_t>(offset), n});
+            static_cast<uint8_t>(ireg16_offset.m_offset), n});
   }
 
   /// LD A, (BC or DE) | A <- mem[BC or DE]
   void ld(const RegA& a, const BasicReg16Addr& rr) {
-    append(boost::format("LD %s, (%s)") % a.str % rr.m_reg.str,  //
+    append(Fmt("i r,r") % "LD" % a % rr,  //
            build(0b00, rr.m_reg, 0b1010));
   }
 
   /// LD A, (nn) | A <- mem[constant16]
   void ld(const RegA& a, const MemAddr& nn) {
     if (nn.isLabel()) {
-      append(boost::format("LD %s, (%s)") % a.str % nn.label,  //
+      append(Fmt("i r,I") % "LD" % a % nn,  //
              {build(0b00, A, D), nn.l, nn.h});
       resolve(nn.label, 1);
     } else {
-      append(boost::format("LD %s, (0%xh)") % a.str % nn.addr,  //
+      append(Fmt("i r,I") % "LD" % a % nn,  //
              {build(0b00, A, D), nn.l, nn.h});
     }
   }
 
   /// LD (BC or DE), A | mem[BC or DE] <- A
   void ld(const BasicReg16Addr& rr, const RegA& a) {
-    append(boost::format("LD (%s), %s") % rr.m_reg.str % a.str,  //
+    append(Fmt("i r,r") % "LD" % rr % a,  //
            {build(0b00, rr.m_reg, 0b0010)});
   }
 
   /// LD (nn), A | mem[constant16] <- A
   void ld(const MemAddr& nn, const RegA& a) {
-    append(boost::format("LD (0%xh), %s") % nn.addr % a.str,  //
+    append(Fmt("i I,r") % "LD" % nn % a,  //
            {build(0b00, F, D), nn.l, nn.h});
   }
 
   /// LD A, I | A <- I
   void ld(const RegA& a, const RegI& i) {
-    append(boost::format("LD %s, %s") % a.str % i.str,  //
+    append(Fmt("i r,r") % "LD" % a % i,  //
            {0xed, 0x57});
   }
 
   /// LD I, A | I <- A
   void ld(const RegI& i, const RegA& a) {
-    append(boost::format("LD %s, %s") % i.str % a.str,  //
+    append(Fmt("i r,r") % "LD" % i % a,  //
            {0xed, 0x47});
   }
 
   /// LD A, R | A <- R
   void ld(const RegA& a, const RegR& r) {
-    append(boost::format("LD %s, %s") % a.str % r.str,  //
+    append(Fmt("i r,r") % "LD" % a % r,  //
            {0xed, 0x5f});
   }
 
   /// LD R, A | R <- A
   void ld(const RegR& r, const RegA& a) {
-    append(boost::format("LD %s, %s") % r.str % a.str,  //
+    append(Fmt("i r,r") % "LD" % r % a,  //
            {0xed, 0x4f});
   }
 
@@ -684,112 +1043,91 @@ class Generator {
 
   /// LD rp, nn | reg16 <- constant16
   void ld(const Reg16& rp, uint16_t nn) {
-    append(boost::format("LD %s, 0%xh") % rp.str % nn,  //
-           {build(0b00, rp, 0b0001),                    //
-            static_cast<uint8_t>(nn & 0xff),
-            static_cast<uint8_t>((nn >> 8) & 0xff)});
+    MemAddr m(nn);
+    append(Fmt("i r,x") % "LD" % rp % nn,  //
+           {build(0b00, rp, 0b0001), m.l, m.h});
   }
   void ld(const Reg16& rp, const std::string& label) {
-    append(boost::format("LD %s, %s") % rp.str % label,  //
-           {build(0b00, rp, 0b0001),                     //
-            0x00, 0x00});
+    append(Fmt("i r,s") % "LD" % rp % label,  //
+           {build(0b00, rp, 0b0001), 0x00, 0x00});
     resolve(label, 1);
   }
 
   /// LD indexreg16, nn | indexreg16 <- constant16
   void ld(const IndexReg16& rp, uint16_t nn) {
-    append(boost::format("LD %s, 0%xh") % rp.str % nn,  //
-           {rp.m_prefix, build(0b00, HL, 0b0001),       //
-            static_cast<uint8_t>(nn & 0xff),
-            static_cast<uint8_t>((nn >> 8) & 0xff)});
+    MemAddr m(nn);
+    append(Fmt("i r,x") % "LD" % rp % nn,  //
+           {rp.m_prefix, build(0b00, HL, 0b0001), m.l, m.h});
   }
   void ld(const IndexReg16& rp, const std::string& label) {
-    append(boost::format("LD %s, %s") % rp.str % label,  //
+    append(Fmt("i r,s") % "LD" % rp % label,  //
            {rp.m_prefix, build(0b00, HL, 0b0001), 0x00, 0x00});
     resolve(label, 2);
   }
 
   /// LD HL, (nn) | reg16 <- mem[constant16]
   void ld(const RegHL& hl, const MemAddr& nn) {
+    append(Fmt("i r,I") % "LD" % hl % nn,  //
+           {build(0b00, hl, 0b1010), nn.l, nn.h});
     if (nn.isLabel()) {
-      append(boost::format("LD %s, (%s)") % hl.str % nn.label,  //
-             {build(0b00, hl, 0b1010), nn.l, nn.h});
       resolve(nn.label, 1);
-    } else {
-      append(boost::format("LD %s, (0%xh)") % hl.str % nn.addr,  //
-             {build(0b00, hl, 0b1010), nn.l, nn.h});
     }
   }
 
   /// LD rp, (nn) | reg16 <- mem[constant16]
   void ld(const BasicReg16& rp, const MemAddr& nn) {
+    append(Fmt("i r,I)") % "LD" % rp % nn,  //
+           {0xed, build(0b01, rp, 0b1011), nn.l, nn.h});
     if (nn.isLabel()) {
-      append(boost::format("LD %s, (%s)") % rp.str % nn.label,  //
-             {0xed, build(0b01, rp, 0b1011), nn.l, nn.h});
       resolve(nn.label, 2);
-    } else {
-      append(boost::format("LD %s, (0%xh)") % rp.str % nn.addr,  //
-             {0xed, build(0b01, rp, 0b1011), nn.l, nn.h});
     }
   }
 
   /// LD IX or IY, (nn) | indexreg16 <- mem[constant16]
   void ld(const IndexReg16& rp, const MemAddr& nn) {
+    append(Fmt("i r,I") % "LD" % rp % nn,  //
+           {rp.m_prefix, build(0b00, rp, 0b1010), nn.l, nn.h});
     if (nn.isLabel()) {
-      append(boost::format("LD %s, (%s)") % rp.str % nn.label,  //
-             {rp.m_prefix, build(0b00, rp, 0b1010), nn.l, nn.h});
       resolve(nn.label, 2);
-    } else {
-      append(boost::format("LD %s, (0%xh)") % rp.str % nn.addr,  //
-             {rp.m_prefix, build(0b00, rp, 0b1010), nn.l, nn.h});
     }
   }
 
   /// LD (nn), HL | mem[constant16] <- reg16
   void ld(const MemAddr& nn, const RegHL& hl) {
+    append(Fmt("i I,r") % "LD" % nn % hl,  //
+           {build(0b00, hl, 0b0010), nn.l, nn.h});
     if (nn.isLabel()) {
-      append(boost::format("LD (%s), %s") % nn.label % hl.str,  //
-             {build(0b00, hl, 0b0010), nn.l, nn.h});
       resolve(nn.label, 1);
-    } else {
-      append(boost::format("LD (0%xh), %s") % nn.addr % hl.str,  //
-             {build(0b00, hl, 0b0010), nn.l, nn.h});
     }
   }
 
   /// LD (nn), rp | mem[constant16] <- reg16
   void ld(const MemAddr& nn, const BasicReg16& rp) {
+    append(Fmt("i I,r") % "LD" % nn % rp,  //
+           {0xed, build(0b01, rp, 0b0011), nn.l, nn.h});
     if (nn.isLabel()) {
-      append(boost::format("LD (%s), %s") % nn.label % rp.str,  //
-             {0xed, build(0b01, rp, 0b0011), nn.l, nn.h});
       resolve(nn.label, 2);
-    } else {
-      append(boost::format("LD (0%xh), %s") % nn.addr % rp.str,  //
-             {0xed, build(0b01, rp, 0b0011), nn.l, nn.h});
     }
   }
 
   /// LD (nn), IX or IY | mem[constant16] <- indexreg16
   void ld(const MemAddr& nn, const IndexReg16& rp) {
+    append(Fmt("i I,r") % "LD" % nn % rp,  //
+           {rp.m_prefix, build(0b00, rp, 0b0010), nn.l, nn.h});
     if (nn.isLabel()) {
-      append(boost::format("LD (%s), %s") % nn.label % rp.str,  //
-             {rp.m_prefix, build(0b00, rp, 0b0010), nn.l, nn.h});
       resolve(nn.label, 2);
-    } else {
-      append(boost::format("LD (0%xh), %s") % nn.addr % rp.str,  //
-             {rp.m_prefix, build(0b00, rp, 0b0010), nn.l, nn.h});
     }
   }
 
   /// LD SP, HL | SP <- HL
   void ld(const RegSP& sp, const RegHL& hl) {
-    append(boost::format("LD %s, %s") % sp.str % hl.str,  //
+    append(Fmt("i r,r") % "LD" % sp % hl,  //
            {0b11111001});
   }
 
   /// LD SP, IX or IY | SP <- IX or IY
   void ld(const RegSP& sp, const IndexReg16& rp) {
-    append(boost::format("LD %s, %s") % sp.str % rp.str,  //
+    append(Fmt("i r,r") % "LD" % sp % rp,  //
            {rp.m_prefix, 0b11111001});
   }
 
@@ -798,25 +1136,25 @@ class Generator {
 
   /// LDI | mem[DE++] <- mem[HL++]; --BC;
   void ldi(void) {
-    append(boost::format("LDI"),  //
+    append(Fmt("i") % "LDI",  //
            {0b1110'1101, 0b1010'0000});
   }
 
   /// LDIR | while(BC!=0) { mem[DE++] <- mem[HL++]; --BC; }
   void ldir(void) {
-    append(boost::format("LDIR"),  //
+    append(Fmt("i") % "LDIR",  //
            {0b1110'1101, 0b1011'0000});
   }
 
   /// LDD | mem[DE--] <- mem[HL--]; --BC;
   void ldd(void) {
-    append(boost::format("LDD"),  //
+    append(Fmt("i") % "LDD",  //
            {0b1110'1101, 0b1010'1000});
   }
 
   /// LDDR | while(BC!=0) { mem[DE--] <- mem[HL--]; --BC; }
   void lddr(void) {
-    append(boost::format("LDDR"),  //
+    append(Fmt("i") % "LDDR",  //
            {0b1110'1101, 0b1011'1000});
   }
 
@@ -825,31 +1163,31 @@ class Generator {
 
   /// EX DE, HL | DE <=> HL
   void ex(const RegDE& de, const RegHL& hl) {
-    append(boost::format("EX %s, %s") % de.str % hl.str,  //
+    append(Fmt("i r,r") % "EX" % de % hl,  //
            {0b1110'1011});
   }
 
   /// EX AF, AF' | AF <=> AF'
   void ex(const RegAF& af, const RegAF& afd) {
-    append(boost::format("EX %s, %s'") % af.str % afd.str,  //
+    append(Fmt("i r,r'") % "EX" % af % afd,  //
            {0b0000'1000});
   }
 
   /// EXX | (BC, DE, HL) <=> (BC', DE', HL')
   void exx(void) {
-    append(boost::format("EXX"),  //
+    append(Fmt("i") % "EXX",  //
            {0b1101'1001});
   }
 
   /// EX (SP), HL | mem[SP] <=> L; mem[SP+1] <=> H;
   void ex(const RegSPAddr& sp, const RegHL& hl) {
-    append(boost::format("EX (%s), %s") % sp.m_reg.str % hl.str,  //
+    append(Fmt("i r,r") % "EX" % sp % hl,  //
            {0b1110'0011});
   }
 
   /// EX (SP), IX or IY | mem[SP] <=> IXL or IYL; mem[SP+1] <=> IXH or IYH;
   void ex(const RegSPAddr& sp, const IndexReg16& rp) {
-    append(boost::format("EX (%s), %s") % sp.m_reg.str % rp.str,  //
+    append(Fmt("i r,r") % "EX" % sp % rp,  //
            {rp.m_prefix, 0b1110'0011});
   }
 
@@ -858,11 +1196,11 @@ class Generator {
 
  private:
   void push_rp_impl(const Reg16& rp) {
-    append(boost::format("PUSH %s") % rp.str,  //
+    append(Fmt("i r") % "PUSH" % rp,  //
            {build(0b11, rp, 0b0101)});
   }
   void pop_rp_impl(const Reg16& rp) {
-    append(boost::format("POP %s") % rp.str,  //
+    append(Fmt("i r") % "POP" % rp,  //
            {build(0b11, rp, 0b0001)});
   }
 
@@ -881,7 +1219,7 @@ class Generator {
 
   /// PUSH IX or IY | mem[SP-1] <- IXH or IYH; mem[SP-2] <- IXL or IYL; SP-= 2;
   void push(const IndexReg16& rp) {
-    append(boost::format("PUSH %s") % rp.str,  //
+    append(Fmt("i r") % "PUSH" % rp,  //
            {rp.m_prefix, build(0b11, rp, 0b0101)});
   }
 
@@ -899,7 +1237,7 @@ class Generator {
 
   /// POP IX or IY | IXH or IYH <- mem[SP]; IXL or IYL <- mem[SP+1]; SP+= 2;
   void pop(const IndexReg16& rp) {
-    append(boost::format("POP %s") % rp.str,  //
+    append(Fmt("i r") % "POP" % rp,  //
            {rp.m_prefix, build(0b11, rp, 0b0001)});
   }
 
@@ -911,56 +1249,52 @@ class Generator {
 
   /// RLCA |
   void rlca(void) {
-    append(boost::format("RLCA"),  //
+    append(Fmt("i") % "RLCA",  //
            {0b0000'0111});
   }
 
   /// RLA |
   void rla(void) {
-    append(boost::format("RLA"),  //
+    append(Fmt("i") % "RLA",  //
            {0b0001'0111});
   }
 
   /// RLC r |
   void rlc(const BasicReg8& r) {
-    append(boost::format("RLC %s") % r.str,  //
+    append(Fmt("i r") % "RLC" % r,  //
            {0b1100'1011, build(0b00, B, r)});
   }
 
   /// RLC (HL) |
   void rlc(const RegHLAddr& hl) {
-    append(boost::format("RLC (%s)") % hl.m_reg.str,  //
+    append(Fmt("i r") % "RLC" % hl,  //
            {0b1100'1011, 0b0000'0110});
   }
 
   /// RLC (IX or IY + d) |
   void rlc(const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("RLC (%s%c0%xh)") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r") % "RLC" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(offset), 0b0000'0110});
+            static_cast<uint8_t>(ireg16_offset.m_offset), 0b0000'0110});
   }
 
   /// RL r |
   void rl(const BasicReg8& r) {
-    append(boost::format("RL %s") % r.str,  //
+    append(Fmt("i r") % "RL" % r,  //
            {0b1100'1011, build(0b00, D, r)});
   }
 
   /// RL (HL) |
   void rl(const RegHLAddr& hl) {
-    append(boost::format("RL (%s)") % hl.m_reg.str,  //
+    append(Fmt("i r") % "RL" % hl,  //
            {0b1100'1011, build(0b00, D, F)});
   }
 
   /// RL (IX or IY + d) |
   void rl(const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("RL (%s%c0%xh)") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r") % "RL" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(offset), 0b0001'0110});
+            static_cast<uint8_t>(ireg16_offset.m_offset), 0b0001'0110});
   }
 
   // ---------------------------------
@@ -968,56 +1302,52 @@ class Generator {
 
   /// RRCA |
   void rrca(void) {
-    append(boost::format("RRCA"),  //
+    append(Fmt("i") % "RRCA",  //
            {0b0000'1111});
   }
 
   /// RRA |
   void rra(void) {
-    append(boost::format("RRA"),  //
+    append(Fmt("i") % "RRA",  //
            {0b0001'1111});
   }
 
   /// RRC r |
   void rrc(const BasicReg8& r) {
-    append(boost::format("RRC %s") % r.str,  //
+    append(Fmt("i r") % "RRC" % r,  //
            {0b1100'1011, build(0b00, C, r)});
   }
 
   /// RRC (HL) |
   void rrc(const RegHLAddr& hl) {
-    append(boost::format("RRC (%s)") % hl.m_reg.str,  //
+    append(Fmt("i r") % "RRC" % hl,  //
            {0b1100'1011, build(0b00, C, F)});
   }
 
   /// RRC (IX or IY + d) |
   void rrc(const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("RRC (%s%c0%xh)") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r") % "RRC" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(offset), build(0b00, C, F)});
+            static_cast<uint8_t>(ireg16_offset.m_offset), build(0b00, C, F)});
   }
 
   /// RR r |
   void rr(const BasicReg8& r) {
-    append(boost::format("RR %s") % r.str,  //
+    append(Fmt("i r") % "RR" % r,  //
            {0b1100'1011, build(0b00, E, r)});
   }
 
   /// RR (HL) |
   void rr(const RegHLAddr& hl) {
-    append(boost::format("RR (%s)") % hl.m_reg.str,  //
+    append(Fmt("i r") % "RR" % hl,  //
            {0b1100'1011, build(0b00, E, F)});
   }
 
   /// RR (IX or IY + d) |
   void rr(const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("RR (%s%c0%xh)") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r") % "RR" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(offset), build(0b00, E, F)});
+            static_cast<uint8_t>(ireg16_offset.m_offset), build(0b00, E, F)});
   }
 
   // ---------------------------------
@@ -1025,23 +1355,21 @@ class Generator {
 
   /// SLA r |
   void sla(const BasicReg8& r) {
-    append(boost::format("SLA %s") % r.str,  //
+    append(Fmt("i r") % "SLA" % r,  //
            {0b1100'1011, build(0b00, H, r)});
   }
 
   /// SLA (HL) |
   void sla(const RegHLAddr& hl) {
-    append(boost::format("SLA (%s)") % hl.m_reg.str,  //
+    append(Fmt("i r") % "SLA" % hl,  //
            {0b1100'1011, build(0b00, H, F)});
   }
 
   /// SLA (IX or IY + d) |
   void sla(const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("SLA (%s%c0%xh)") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r") % "SLA" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(offset), build(0b00, H, F)});
+            static_cast<uint8_t>(ireg16_offset.m_offset), build(0b00, H, F)});
   }
 
   // ---------------------------------
@@ -1049,42 +1377,39 @@ class Generator {
 
   /// SRA r |
   void sra(const BasicReg8& r) {
-    append(boost::format("SRA %s") % r.str,  //
+    append(Fmt("i r") % "SRA" % r,  //
            {0b1100'1011, build(0b00, L, r)});
   }
 
   /// SRA (HL) |
   void sra(const RegHLAddr& hl) {
-    append(boost::format("SRA (%s)") % hl.m_reg.str,  //
+    append(Fmt("i r") % "SRA" % hl,  //
            {0b1100'1011, build(0b00, L, F)});
   }
+
   /// SRA (IX or IY + d) |
   void sra(const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("SRA (%s%c0%xh)") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r") % "SRA" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(offset), build(0b00, L, F)});
+            static_cast<uint8_t>(ireg16_offset.m_offset), build(0b00, L, F)});
   }
 
   /// SRL r |
   void srl(const BasicReg8& r) {
-    append(boost::format("SRL %s") % r.str,  //
+    append(Fmt("i r") % "SRL" % r,  //
            {0b1100'1011, build(0b00, A, r)});
   }
 
   /// SRL (HL) |
   void srl(const RegHLAddr& hl) {
-    append(boost::format("SRL (%s)") % hl.m_reg.str,  //
+    append(Fmt("i r") % "SRL" % hl,  //
            {0b1100'1011, build(0b00, A, F)});
   }
   /// SRL (IX or IY + d) |
   void srl(const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("SRL (%s%c0%xh)") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r") % "SRL" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(offset), build(0b00, A, F)});
+            static_cast<uint8_t>(ireg16_offset.m_offset), build(0b00, A, F)});
   }
 
   // =========================================================================
@@ -1095,79 +1420,71 @@ class Generator {
 
   /// ADD A, r | A <- A + reg8
   void add(const RegA& a, const BasicReg8& r) {
-    append(boost::format("ADD %s, %s") % a.str % r.str,  //
+    append(Fmt("i r,r") % "ADD" % a % r,  //
            {build(0b10, B, r)});
   }
 
   /// ADD A, n | A <- A + constant8
   void add(const RegA& a, uint8_t n) {
-    append(boost::format("ADD %s, 0%xh") % a.str % static_cast<int>(n),  //
+    append(Fmt("i r,x") % "ADD" % a % n,  //
            {build(0b11, B, F), n});
   }
 
   /// ADD A, (HL) | A <- A + mem[HL]
   void add(const RegA& a, const RegHLAddr& r) {
-    append(boost::format("ADD %s, (%s)") % a.str % r.m_reg.str,  //
+    append(Fmt("i r,r") % "ADD" % a % r,  //
            {build(0b10, B, F)});
   }
 
   /// ADD A, (IX or IY + d) | A <- A + mem[IX or IY + d]
   void add(const RegA& a, const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("ADD %s, (%s%c0%xh)") % a.str %
-               ireg16_offset.m_reg.str % (offset < 0 ? '-' : '+') %
-               (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r,r") % "ADD" % a % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, B, F),
-            static_cast<uint8_t>(offset)});
+            static_cast<uint8_t>(ireg16_offset.m_offset)});
   }
 
   /// ADC A, r | A <- A + reg8 + carry
   void adc(const RegA& a, const BasicReg8& r) {
-    append(boost::format("ADC %s, %s") % a.str % r.str,  //
+    append(Fmt("i r,r") % "ADC" % a % r,  //
            {build(0b10, C, r)});
   }
 
   /// ADC A, n | A <- A + constant8 + carry
   void adc(const RegA& a, uint8_t n) {
-    append(boost::format("ADC %s, 0%xh") % a.str % static_cast<int>(n),  //
+    append(Fmt("i r,x") % "ADC" % a % n,  //
            {build(0b11, C, F), n});
   }
 
   /// ADC A, (HL) | A <- A + mem[HL] + carry
   void adc(const RegA& a, const RegHLAddr& r) {
-    append(boost::format("ADC %s, (%s)") % a.str % r.m_reg.str,  //
+    append(Fmt("i r,r") % "ADC" % a % r,  //
            {build(0b10, C, F)});
   }
 
   /// ADC A, (IX or IY + d) | A <- A + mem[IX or IY + d] + carry
   void adc(const RegA& a, const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("ADC %s, (%s%c0%xh)") % a.str %
-               ireg16_offset.m_reg.str % (offset < 0 ? '-' : '+') %
-               (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r,r") % "ADC" % a % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, C, F),
-            static_cast<uint8_t>(offset)});
+            static_cast<uint8_t>(ireg16_offset.m_offset)});
   }
 
   /// INC r | reg8 <- reg8 + 1
   void inc(const BasicReg8& r) {
-    append(boost::format("INC %s") % r.str,  //
+    append(Fmt("i r") % "INC" % r,  //
            {build(0b00, r, H)});
   }
 
   /// INC (HL) | mem[HL] <- mem[HL] + 1
   void inc(const RegHLAddr& r) {
-    append(boost::format("INC (%s)") % r.m_reg.str,  //
+    append(Fmt("i r") % "INC" % r,  //
            {build(0b00, F, H)});
   }
 
   /// INC (IX or IY + d) | mem[IX or IY + d] <- mem[IX or IY + d] + 1
   void inc(const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("INC (%s%c0%xh)") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r") % "INC" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b00, F, H),
-            static_cast<uint8_t>(offset)});
+            static_cast<uint8_t>(ireg16_offset.m_offset)});
   }
 
   // ---------------------------------
@@ -1175,79 +1492,71 @@ class Generator {
 
   /// SUB A, r | A <- A - reg8
   void sub(const RegA& a, const BasicReg8& r) {
-    append(boost::format("SUB %s, %s") % a.str % r.str,  //
+    append(Fmt("i r,r") % "SUB" % a % r,  //
            {build(0b10, D, r)});
   }
 
   /// SUB A, n | A <- A - constant8
   void sub(const RegA& a, uint8_t n) {
-    append(boost::format("SUB %s, 0%xh") % a.str % static_cast<int>(n),  //
+    append(Fmt("i r,x") % "SUB" % a % n,  //
            {build(0b11, D, F), n});
   }
 
   /// SUB A, (HL) | A <- A - mem[HL]
   void sub(const RegA& a, const RegHLAddr& r) {
-    append(boost::format("SUB %s, (%s)") % a.str % r.m_reg.str,  //
+    append(Fmt("i r,r") % "SUB" % a % r,  //
            {build(0b10, D, F)});
   }
 
   /// SUB A, (IX or IY + d) | A <- A - mem[IX or IY + d]
   void sub(const RegA& a, const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("SUB %s, (%s%c0%xh)") % a.str %
-               ireg16_offset.m_reg.str % (offset < 0 ? '-' : '+') %
-               (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r,r") % "SUB" % a % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, D, F),
-            static_cast<uint8_t>(offset)});
+            static_cast<uint8_t>(ireg16_offset.m_offset)});
   }
 
   /// SBC A, r | A <- A - reg8 - carry
   void sbc(const RegA& a, const BasicReg8& r) {
-    append(boost::format("SBC %s, %s") % a.str % r.str,  //
+    append(Fmt("i r,r") % "SBC" % a % r,  //
            {build(0b10, E, r)});
   }
 
   /// SBC A, n | A <- A - constant8 - carry
   void sbc(const RegA& a, uint8_t n) {
-    append(boost::format("SBC %s, 0%xh") % a.str % static_cast<int>(n),  //
+    append(Fmt("i r,x") % "SBC" % a % n,  //
            {build(0b11, E, F), n});
   }
 
   /// SBC A, (HL) | A <- A - mem[HL] - carry
   void sbc(const RegA& a, const RegHLAddr& r) {
-    append(boost::format("SBC %s, (%s)") % a.str % r.m_reg.str,  //
+    append(Fmt("i r,r") % "SBC" % a % r,  //
            {build(0b10, E, F)});
   }
 
   /// SBC A, (IX or IY + d) | A <- A - mem[IX or IY + d] - carry
   void sbc(const RegA& a, const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("SBC %s, (%s%c0%xh)") % a.str %
-               ireg16_offset.m_reg.str % (offset < 0 ? '-' : '+') %
-               (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r,r") % "SBC" % a % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, E, F),
-            static_cast<uint8_t>(offset)});
+            static_cast<uint8_t>(ireg16_offset.m_offset)});
   }
 
   /// DEC r | reg8 <- reg8 - 1
   void dec(const BasicReg8& r) {
-    append(boost::format("DEC %s") % r.str,  //
+    append(Fmt("i r") % "DEC" % r,  //
            {build(0b00, r, L)});
   }
 
   /// DEC (HL) | mem[HL] <- mem[HL] - 1
   void dec(const RegHLAddr& r) {
-    append(boost::format("DEC (%s)") % r.m_reg.str,  //
+    append(Fmt("i r") % "DEC" % r,  //
            {build(0b00, F, L)});
   }
 
   /// DEC (IX or IY + d) | mem[IX or IY + d] <- mem[IX or IY + d] - 1
   void dec(const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("DEC (%s%c0%xh)") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r") % "DEC" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b00, F, L),
-            static_cast<uint8_t>(offset)});
+            static_cast<uint8_t>(ireg16_offset.m_offset)});
   }
 
   // =========================================================================
@@ -1255,79 +1564,79 @@ class Generator {
 
   /// ADD HL, rp | HL <- HL + reg16
   void add(const RegHL& hl, const BasicReg16& rp) {
-    append(boost::format("ADD %s, %s") % hl.str % rp.str,  //
+    append(Fmt("i r,r") % "ADD" % hl % rp,  //
            {build(0b00, rp, 0b1001)});
   }
 
   /// ADD HL, HL | HL <- HL + HL
   void add(const RegHL& hl, const RegHL& rp) {
-    append(boost::format("ADD %s, %s") % hl.str % rp.str,  //
+    append(Fmt("i r,r") % "ADD" % hl % rp,  //
            {build(0b00, rp, 0b1001)});
   }
 
   /// ADC HL, rp | HL <- HL + reg16 + carry
   void adc(const RegHL& hl, const BasicReg16& rp) {
-    append(boost::format("ADC %s, %s") % hl.str % rp.str,  //
+    append(Fmt("i r,r") % "ADC" % hl % rp,  //
            {0b1110'1101, build(0b01, rp, 0b1010)});
   }
 
   /// ADC HL, HL | HL <- HL + HL + carry
   void adc(const RegHL& hl, const RegHL& rp) {
-    append(boost::format("ADC %s, %s") % hl.str % rp.str,  //
+    append(Fmt("i r,r") % "ADC" % hl % rp,  //
            {0b1110'1101, build(0b01, rp, 0b1010)});
   }
 
   /// ADD IX or IY, rp | IX or IY <- IX or IY + reg16
   void add(const IndexReg16& ireg16, const BasicReg16& rp) {
-    append(boost::format("ADD %s, %s") % ireg16.str % rp.str,  //
+    append(Fmt("i r,r") % "ADD" % ireg16 % rp,  //
            {ireg16.m_prefix, build(0b00, rp, 0b1001)});
   }
 
   /// INC rp | reg16 <- reg16 + 1
   void inc(const BasicReg16& rp) {
-    append(boost::format("INC %s") % rp.str,  //
+    append(Fmt("i r") % "INC" % rp,  //
            {build(0b00, rp, 0b0011)});
   }
 
   /// INC HL | HL <- HL + 1
   void inc(const RegHL& rp) {
-    append(boost::format("INC %s") % rp.str,  //
+    append(Fmt("i r") % "INC" % rp,  //
            {build(0b00, rp, 0b0011)});
   }
 
   /// INC IX or IY | IX or IY <- IX or IY + 1
   void inc(const IndexReg16& rp) {
-    append(boost::format("INC %s") % rp.str,  //
+    append(Fmt("i r") % "INC" % rp,  //
            {rp.m_prefix, build(0b00, rp, 0b0011)});
   }
 
   /// SBC HL, rp | HL <- HL - reg16 - carry
   void sbc(const RegHL& hl, const BasicReg16& rp) {
-    append(boost::format("SBC %s, %s") % hl.str % rp.str,  //
+    append(Fmt("i r,r") % "SBC" % hl % rp,  //
            {0b1110'1101, build(0b1, rp, 0b0010)});
   }
 
   /// SBC HL, HL | HL <- HL - HL - carry
   void sbc(const RegHL& hl, const RegHL& rp) {
-    append(boost::format("SBC %s, %s") % hl.str % rp.str,  //
+    append(Fmt("i r,r") % "SBC" % hl % rp,  //
            {0b1110'1101, build(0b01, rp, 0b0010)});
   }
 
   /// DEC rp | reg16 <- reg16 - 1
   void dec(const BasicReg16& rp) {
-    append(boost::format("DEC %s") % rp.str,  //
+    append(Fmt("i r") % "DEC" % rp,  //
            {build(0b00, rp, 0b1011)});
   }
 
   /// DEC HL | HL <- HL - 1
   void dec(const RegHL& rp) {
-    append(boost::format("DEC %s") % rp.str,  //
+    append(Fmt("i r") % "DEC" % rp,  //
            {build(0b00, rp, 0b1011)});
   }
 
   /// DEC IX or IY |IX or IY <- IX or IY - 1
   void dec(const IndexReg16& rp) {
-    append(boost::format("DEC %s") % rp.str,  //
+    append(Fmt("i r") % "DEC" % rp,  //
            {rp.m_prefix, build(0b00, rp, 0b1011)});
   }
 
@@ -1336,96 +1645,90 @@ class Generator {
 
   /// AND r | A <- A & reg8
   void and (const BasicReg8& r) {
-    append(boost::format("AND %s") % r.str,  //
+    append(Fmt("i r") % "AND" % r,  //
            {build(0b10, H, r)});
   }
 
   /// AND n | A <- A & constant8
   void and (uint8_t n) {
-    append(boost::format("AND 0%xh") % static_cast<int>(n),  //
+    append(Fmt("i x") % "AND" % n,  //
            {build(0b11, H, F), n});
   }
 
   /// AND (HL) | A <- A & mem[HL]
   void and (const RegHLAddr& hl) {
-    append(boost::format("AND (%s)") % hl.m_reg.str,  //
+    append(Fmt("i r") % "AND" % hl,  //
            {build(0b10, H, F)});
   }
 
   /// AND (IX or IY + d) | A <- A & mem[IX or IY + d]
   void and (const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("AND (%s%c0%xh)") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r") % "AND" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, H, F),
-            static_cast<uint8_t>(offset)});
+            static_cast<uint8_t>(ireg16_offset.m_offset)});
   }
 
   /// OR r | A <- A | reg8
   void or (const BasicReg8& r) {
-    append(boost::format("OR %s") % r.str,  //
+    append(Fmt("i r") % "OR" % r,  //
            {build(0b10, F, r)});
   }
 
   /// OR n | A <- A | constant8
   void or (uint8_t n) {
-    append(boost::format("OR 0%xh") % static_cast<int>(n),  //
+    append(Fmt("i x") % "OR" % n,  //
            {build(0b11, F, F), n});
   }
 
   /// OR (HL) | A <- A | mem[HL]
   void or (const RegHLAddr& hl) {
-    append(boost::format("OR (%s)") % hl.m_reg.str,  //
+    append(Fmt("i r") % "OR" % hl,  //
            {build(0b10, F, F)});
   }
 
   /// OR (IX or IY + d) | A <- A | mem[IX or IY + d]
   void or (const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("OR (%s%c0%xh)") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r") % "OR" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, F, F),
-            static_cast<uint8_t>(offset)});
+            static_cast<uint8_t>(ireg16_offset.m_offset)});
   }
 
 #define XZ80_XOR xor
 
   /// XOR r | A <- A ^ reg8
   void XZ80_XOR(const BasicReg8& r) {
-    append(boost::format("XOR %s") % r.str,  //
+    append(Fmt("i r") % "XOR" % r,  //
            {build(0b10, L, r)});
   }
 
   /// XOR n | A <- A ^ constant8
   void XZ80_XOR(uint8_t n) {
-    append(boost::format("XOR 0%xh") % static_cast<int>(n),  //
+    append(Fmt("i x") % "XOR" % n,  //
            {build(0b11, L, F), n});
   }
 
   /// XOR (HL) | A <- A ^ mem[HL]
   void XZ80_XOR(const RegHLAddr& hl) {
-    append(boost::format("XOR (%s)") % hl.m_reg.str,  //
+    append(Fmt("i r") % "XOR" % hl,  //
            {build(0b10, L, F)});
   }
 
   /// XOR (IX or IY + d) | A <- A ^ mem[IX or IY + d]
   void XZ80_XOR(const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("XOR (%s%c0%xh)") % ireg16_offset.m_reg.str %
-               (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset),  //
+    append(Fmt("i r") % "XOR" % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, build(0b10, L, F),
-            static_cast<uint8_t>(offset)});
+            static_cast<uint8_t>(ireg16_offset.m_offset)});
   }
 
   /// CPL | A <- ~A
   void cpl(void) {
-    append(boost::format("CPL"),  //
+    append(Fmt("i") % "CPL",  //
            {0b0010'1111});
   }
 
   /// NEG | A <- ~A + 1
   void neg(void) {
-    append(boost::format("NEG"),  //
+    append(Fmt("i") % "NEG",  //
            {0b1110'1101, 0b0100'0100});
   }
 
@@ -1434,121 +1737,118 @@ class Generator {
 
   /// CCF | carry <- ~carry
   void ccf(void) {
-    append(boost::format("CCF"),  //
+    append(Fmt("i") % "CCF",  //
            {0b0011'1111});
   }
 
   /// SCF | carry <- 1
   void scf(void) {
-    append(boost::format("SCF"),  //
+    append(Fmt("i") % "SCF",  //
            {0b0011'0111});
   }
 
   /// BIT b, r | Z <- ~r_b
   void bit(uint8_t b, const BasicReg8& r) {
     if (7 < b) {
-      throw std::out_of_range(
-          (boost::format("BIT %d:out of range") % static_cast<int>(b)).str());
+      char buf[32];
+      std::sprintf(buf, "BIT %d:out of range", b);
+      throw std::out_of_range(buf);
     }
-    append(boost::format("BIT %d, %s") % static_cast<int>(b) % r.str,  //
+    append(Fmt("i d,r") % "BIT" % b % r,  //
            {0b1100'1011, static_cast<uint8_t>(0b0100'0000 | b << 3 | r.id)});
   }
 
   /// BIT b, (HL) | Z <- ~mem[HL]_b
   void bit(uint8_t b, const RegHLAddr& hl) {
     if (7 < b) {
-      throw std::out_of_range(
-          (boost::format("BIT %d:out of range") % static_cast<int>(b)).str());
+      char buf[32];
+      std::sprintf(buf, "BIT %d:out of range", b);
+      throw std::out_of_range(buf);
     }
-    append(
-        boost::format("BIT %d, (%s)") % static_cast<int>(b) % hl.m_reg.str,  //
-        {0b1100'1011, static_cast<uint8_t>(0b0100'0000 | b << 3 | 0b110)});
+    append(Fmt("i d,r") % "BIT" % b % hl,  //
+           {0b1100'1011, static_cast<uint8_t>(0b0100'0000 | b << 3 | 0b110)});
   }
 
   /// BIT b, (IX or IY +d) | Z <- ~mem[IX or IY +d]_b
   void bit(uint8_t b, const IndenexReg16AddrOffset& ireg16_offset) {
     if (7 < b) {
-      throw std::out_of_range(
-          (boost::format("BIT %d:out of range") % static_cast<int>(b)).str());
+      char buf[32];
+      std::sprintf(buf, "BIT %d:out of range", b);
+      throw std::out_of_range(buf);
     }
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("BIT %d, (%s%c0%xh)") % static_cast<int>(b) %
-               ireg16_offset.m_reg.str % (offset < 0 ? '-' : '+') %
-               (offset < 0 ? -offset : offset),  //
+    append(Fmt("i d,r") % "BIT" % b % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(offset),
+            static_cast<uint8_t>(ireg16_offset.m_offset),
             static_cast<uint8_t>(0b0100'0000 | b << 3 | 0b110)});
   }
 
   /// SET b, r | r_b <- 1
   void set(uint8_t b, const BasicReg8& r) {
     if (7 < b) {
-      throw std::out_of_range(
-          (boost::format("SET %d:out of range") % static_cast<int>(b)).str());
+      char buf[32];
+      std::sprintf(buf, "SET %d:out of range", b);
+      throw std::out_of_range(buf);
     }
-    append(boost::format("SET %d, %s") % static_cast<int>(b) % r.str,  //
+    append(Fmt("i d,r") % "SET" % b % r,  //
            {0b1100'1011, static_cast<uint8_t>(0b1100'0000 | b << 3 | r.id)});
   }
 
   /// SET b, (HL) | mem[HL]_b <- 1
   void set(uint8_t b, const RegHLAddr& hl) {
     if (7 < b) {
-      throw std::out_of_range(
-          (boost::format("SET %d:out of range") % static_cast<int>(b)).str());
+      char buf[32];
+      std::sprintf(buf, "SET %d:out of range", b);
+      throw std::out_of_range(buf);
     }
-    append(
-        boost::format("SET %d, (%s)") % static_cast<int>(b) % hl.m_reg.str,  //
-        {0b1100'1011, static_cast<uint8_t>(0b1100'0000 | b << 3 | 0b110)});
+    append(Fmt("i d,r") % "SET" % b % hl,  //
+           {0b1100'1011, static_cast<uint8_t>(0b1100'0000 | b << 3 | 0b110)});
   }
 
   /// SET b, (IX or IY +d) | mem[IX or IY +d]_b <- 1
   void set(uint8_t b, const IndenexReg16AddrOffset& ireg16_offset) {
     if (7 < b) {
-      throw std::out_of_range(
-          (boost::format("SET %d:out of range") % static_cast<int>(b)).str());
+      char buf[32];
+      std::sprintf(buf, "SET %d:out of range", b);
+      throw std::out_of_range(buf);
     }
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("SET %d, (%s%c0%xh)") % static_cast<int>(b) %
-               ireg16_offset.m_reg.str % (offset < 0 ? '-' : '+') %
-               (offset < 0 ? -offset : offset),  //
+    append(Fmt("i d,r") % "SET" % b % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(offset),
+            static_cast<uint8_t>(ireg16_offset.m_offset),
             static_cast<uint8_t>(0b1100'0000 | b << 3 | 0b110)});
   }
 
   /// RES b, r | r_b <- 0
   void res(uint8_t b, const BasicReg8& r) {
     if (7 < b) {
-      throw std::out_of_range(
-          (boost::format("RES %d:out of range") % static_cast<int>(b)).str());
+      char buf[32];
+      std::sprintf(buf, "RES %d:out of range", b);
+      throw std::out_of_range(buf);
     }
-    append(boost::format("RES %d, %s") % static_cast<int>(b) % r.str,  //
+    append(Fmt("i d,r") % "RES" % b % r,  //
            {0b1100'1011, static_cast<uint8_t>(0b1000'0000 | b << 3 | r.id)});
   }
 
   /// RES b, (HL) | mem[HL]_b <- 0
   void res(uint8_t b, const RegHLAddr& hl) {
     if (7 < b) {
-      throw std::out_of_range(
-          (boost::format("RES %d:out of range") % static_cast<int>(b)).str());
+      char buf[32];
+      std::sprintf(buf, "RES %d:out of range", b);
+      throw std::out_of_range(buf);
     }
-    append(
-        boost::format("RES %d, (%s)") % static_cast<int>(b) % hl.m_reg.str,  //
-        {0b1100'1011, static_cast<uint8_t>(0b1000'0000 | b << 3 | 0b110)});
+    append(Fmt("i d,r") % "RES" % b % hl,  //
+           {0b1100'1011, static_cast<uint8_t>(0b1000'0000 | b << 3 | 0b110)});
   }
 
   /// RES b, (IX or IY +d) | mem[IX or IY +d]_b <- 0
   void res(uint8_t b, const IndenexReg16AddrOffset& ireg16_offset) {
     if (7 < b) {
-      throw std::out_of_range(
-          (boost::format("RES %d:out of range") % static_cast<int>(b)).str());
+      char buf[32];
+      std::sprintf(buf, "RES %d:out of range", b);
+      throw std::out_of_range(buf);
     }
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("RES %d, (%s%c0%xh)") % static_cast<int>(b) %
-               ireg16_offset.m_reg.str % (offset < 0 ? '-' : '+') %
-               (offset < 0 ? -offset : offset),  //
+    append(Fmt("i d,r") % "RES" % b % ireg16_offset,  //
            {ireg16_offset.m_reg.m_prefix, 0b1100'1011,
-            static_cast<uint8_t>(offset),
+            static_cast<uint8_t>(ireg16_offset.m_offset),
             static_cast<uint8_t>(0b1000'0000 | b << 3 | 0b110)});
   }
 
@@ -1557,52 +1857,51 @@ class Generator {
 
   /// CPI | Frag <- A - mem[HL]; HL <- HL+1; BC <- BC-1;
   void cpi(void) {
-    append(boost::format("CPI"),  //
+    append(Fmt("i") % "CPI",  //
            {0b1110'1101, 0b1010'0001});
   }
 
   /// CPIR | while BC!=0 and A!=mem[HL] { Frag <- A - mem[HL]; HL <- HL+1; BC <- BC-1; }
   void cpir(void) {
-    append(boost::format("CPIR"),  //
+    append(Fmt("i") % "CPIR",  //
            {0b1110'1101, 0b1011'0001});
   }
 
   /// CPD | Frag <- A - mem[HL]; HL <- HL-1; BC <- BC-1;
   void cpd(void) {
-    append(boost::format("CPD"),  //
+    append(Fmt("i") % "CPD",  //
            {0b1110'1101, 0b1010'1001});
   }
 
   /// CPDR | while BC!=0 and A!=mem[HL] { Frag <- A - mem[HL]; HL <- HL-1; BC <- BC-1; }
   void cpdr(void) {
-    append(boost::format("CPDR"),  //
+    append(Fmt("i") % "CPDR",  //
            {0b1110'1101, 0b1011'1001});
   }
 
   /// CP r | Frag <- A - reg8
   void cp(const BasicReg8& r) {
-    append(boost::format("CP %s") % r.str,  //
+    append(Fmt("i r") % "CP" % r,  //
            {build(0b10, A, r)});
   }
 
   /// CP n | Frag <- A - constant8
   void cp(uint8_t n) {
-    append(boost::format("CP 0%xh") % static_cast<int>(n),  //
+    append(Fmt("i x") % "CP" % n,  //
            {0b1111'1110, n});
   }
 
   /// CP (HL) | Frag <- A - mem[HL]
   void cp(const RegHLAddr& hl) {
-    append(boost::format("CP (%s)") % hl.m_reg.str,  //
+    append(Fmt("i r") % "CP" % hl,  //
            {build(0b10, A, F)});
   }
 
   /// CP (IX or IY +d) | Frag <- A - mem[IX or IY +d]
   void cp(const IndenexReg16AddrOffset& ireg16_offset) {
-    const int offset = ireg16_offset.m_offset;
-    append(boost::format("CP (%s%c0%xh)")                                                               //
-               % ireg16_offset.m_reg.str % (offset < 0 ? '-' : '+') % (offset < 0 ? -offset : offset),  //
-           {ireg16_offset.m_reg.m_prefix, 0b1011'1110, static_cast<uint8_t>(offset)});
+    append(Fmt("i r") % "CP" % ireg16_offset,  //
+           {ireg16_offset.m_reg.m_prefix, 0b1011'1110,
+            static_cast<uint8_t>(ireg16_offset.m_offset)});
   }
 
   // =========================================================================
@@ -1611,12 +1910,12 @@ class Generator {
   /// JP nn | PC <- constant16
   void jp(uint16_t nn) {
     MemAddr addr(nn);
-    append(boost::format("JP 0%xh") % nn,  //
+    append(Fmt("i x") % "JP" % nn,  //
            {0b1100'0011, addr.l, addr.h});
   }
   void jp(const std::string& label) {
     MemAddr addr(label);
-    append(boost::format("JP %s") % label,  //
+    append(Fmt("i s") % "JP" % label,  //
            {0b1100'0011, addr.l, addr.h});
     resolve(label, 1);
   }
@@ -1624,12 +1923,12 @@ class Generator {
   /// JP cc,nn | PC <- constant16 if cc
   void jp(const CondBase& cc, uint16_t nn) {
     MemAddr addr(nn);
-    append(boost::format("JP %s, 0%xh") % cc.str % nn,  //
+    append(Fmt("i c,x") % "JP" % cc % nn,  //
            {build(0b11, cc, 0b010), addr.l, addr.h});
   }
   void jp(const CondBase& cc, const std::string& label) {
     MemAddr addr(label);
-    append(boost::format("JP %s, %s") % cc.str % label,  //
+    append(Fmt("i c,s") % "JP" % cc % label,  //
            {build(0b11, cc, 0b010), addr.l, addr.h});
     resolve(label, 1);
   }
@@ -1637,15 +1936,16 @@ class Generator {
   /// JR e | PC <- PC + e
   void jr(int16_t e) {
     if (e < -126 || 129 < e) {
-      throw std::out_of_range((boost::format("JR %d:out of range") % e).str());
+      char buf[32];
+      std::sprintf(buf, "JR %d:out of range", e);
+      throw std::out_of_range(buf);
     }
     const int offset = static_cast<int>(e) - 2;
-    append(
-        boost::format("JR $%c%d") % (e < 0 ? '-' : '+') % (e < 0 ? -e : e),  //
-        {0b0001'1000, static_cast<uint8_t>(offset)});
+    append(Fmt("i o") % "JR" % e,  //
+           {0b0001'1000, static_cast<uint8_t>(offset)});
   }
   void jr(const std::string& label) {
-    append(boost::format("JR %s") % label,  //
+    append(Fmt("i s") % "JR" % label,  //
            {0b0001'1000, 0x00});
     resolve(label, 1, true);
   }
@@ -1653,45 +1953,45 @@ class Generator {
   /// JR cc,e | PC <- PC + e if cc
   void jr(const AllCond& cc, int16_t e) {
     if (e < -126 || 129 < e) {
-      throw std::out_of_range((boost::format("JR %d:out of range") % e).str());
+      char buf[32];
+      std::sprintf(buf, "JR %d:out of range", e);
+      throw std::out_of_range(buf);
     }
     const int offset = static_cast<int>(e) - 2;
-    append(boost::format("JR %s, $%c%d") % cc.str         //
-               % (e < 0 ? '-' : '+') % (e < 0 ? -e : e),  //
+    append(Fmt("i c,o") % "JR" % cc % e,  //
            {build(0b0010'0000, cc), static_cast<uint8_t>(offset)});
   }
   void jr(const AllCond& cc, const std::string& label) {
-    append(boost::format("JR %s, %s") % cc.str  //
-               % label,                         //
+    append(Fmt("i c,s") % "JR" % cc % label,  //
            {build(0b0010'0000, cc), 0x00});
     resolve(label, 1, true);
   }
 
   /// JP (HL) | PC <- mem[HL]
   void jp(const RegHLAddr& hl) {
-    append(boost::format("JP (%s)") % hl.m_reg.str,  //
+    append(Fmt("i r") % "JP" % hl,  //
            {0b1110'1001});
   }
 
   /// JP (IX or IY) | PC <- mem[IX or IY]
   void jp(const IndenexReg16Addr& rp) {
-    append(boost::format("JP (%s)") % rp.m_reg.str,  //
+    append(Fmt("i r") % "JP" % rp,  //
            {rp.m_reg.m_prefix, 0b1110'1001});
   }
 
   /// DJNZ e | if B!=0 then PC <- PC + e; B <- B -1; end
   void djnz(int16_t e) {
     if (e < -126 || 129 < e) {
-      throw std::out_of_range(
-          (boost::format("DJNZ %d:out of range") % e).str());
+      char buf[32];
+      std::sprintf(buf, "DJNZ %d:out of range", e);
+      throw std::out_of_range(buf);
     }
     const int offset = static_cast<int>(e) - 2;
-    append(boost::format("DJNZ $%c%d") %                //
-               (e < 0 ? '-' : '+') % (e < 0 ? -e : e),  //
+    append(Fmt("i o") % "DJNZ" % e,  //
            {0b0001'0000, static_cast<uint8_t>(offset)});
   }
   void djnz(const std::string& label) {
-    append(boost::format("DJNZ %s") % label,  //
+    append(Fmt("i s") % "DJNZ" % label,  //
            {0b0001'0000, 0x00});
     resolve(label, 1, true);
   }
@@ -1700,12 +2000,12 @@ class Generator {
   ///         | SP <- SP - 2; PC <- constant16;
   void call(uint16_t nn) {
     const MemAddr ad(nn);
-    append(boost::format("CALL 0%xh") % nn,  //
+    append(Fmt("i x") % "CALL" % nn,  //
            {0b1100'1101, ad.l, ad.h});
   }
   void call(const std::string& label) {
     const MemAddr ad(label);
-    append(boost::format("CALL %s") % label,  //
+    append(Fmt("i s") % "CALL" % label,  //
            {0b1100'1101, ad.l, ad.h});
     resolve(label, 1);
   }
@@ -1714,37 +2014,37 @@ class Generator {
   ///             | SP <- SP - 2; PC <- constant16; end
   void call(const CondBase& cc, uint16_t nn) {
     const MemAddr ad(nn);
-    append(boost::format("CALL %s, 0%xh") % cc.str % nn,  //
+    append(Fmt("i c,x") % "CALL" % cc % nn,  //
            {build(0b11, cc, 0b100), ad.l, ad.h});
   }
   void call(const CondBase& cc, const std::string& label) {
     const MemAddr ad(label);
-    append(boost::format("CALL %s, %s") % cc.str % label,  //
+    append(Fmt("i c,s") % "CALL" % cc % label,  //
            {build(0b11, cc, 0b100), ad.l, ad.h});
     resolve(label, 1);
   }
 
   /// RET | PCL <- mem[SP]; PCH <- mem[SP+1]; SP <- SP+2
   void ret(void) {
-    append(boost::format("RET"),  //
+    append(Fmt("i") % "RET",  //
            {0b1100'1001});
   }
 
   /// RET cc | if cc then PCL <- mem[SP]; PCH <- mem[SP+1]; SP <- SP+2; end
   void ret(const CondBase& cc) {
-    append(boost::format("RET %s") % cc.str,  //
+    append(Fmt("i c") % "RET" % cc,  //
            {build(0b11, cc, 0b000)});
   }
 
   /// RETI | PCL <- mem[SP]; PCH <- mem[SP+1]; SP <- SP+2; IFF1 <- IFF2
   void reti(void) {
-    append(boost::format("RETI"),  //
+    append(Fmt("i") % "RETI",  //
            {0b1110'1101, 0b0100'1101});
   }
 
   /// RETN | PCL <- mem[SP]; PCH <- mem[SP+1]; SP <- SP+2; IFF1 <- IFF2
   void retn(void) {
-    append(boost::format("RETN"),  //
+    append(Fmt("i") % "RETN",  //
            {0b1110'1101, 0b0100'0101});
   }
 
@@ -1752,40 +2052,42 @@ class Generator {
   ///       | Only p = 0, 8, 16, 24, 32, 40, 48, 56
   void rst(uint16_t p) {
     if (p % 8 != 0 || 7 * 8 < p) {
-      throw std::out_of_range(
-          (boost::format("RST %d:invalid argument") % p).str());
+      char buf[32];
+      std::sprintf(buf, "RST 0%xh:invalid argument", p);
+      throw std::invalid_argument(buf);
     }
     const uint8_t insn = 0b1100'0111 | p;
-    append(boost::format("RST 0%xh") % p,  //
+    append(Fmt("i x") % "RST" % p,  //
            {insn});
   }
+
   // =========================================================================
   // CPU制御命令
 
   // -------------------------------------------------------------------------
   // 動作・割り込み設定命令
 
-  /// NOT | Do nothing.
+  /// NOP | Do nothing.
   void nop(void) {
-    append(boost::format("NOP"),  //
+    append(Fmt("i") % "NOP",  //
            {0b0000'0000});
   }
 
   /// HALT | Halt.
   void halt(void) {
-    append(boost::format("HALT"),  //
+    append(Fmt("i") % "HALT",  //
            {0b0111'0110});
   }
 
   /// DI | Disable interrupt.
   void di(void) {
-    append(boost::format("DI"),  //
+    append(Fmt("i") % "DI",  //
            {0b1111'0011});
   }
 
   /// EI | Enable interrupt.
   void ei(void) {
-    append(boost::format("EI"),  //
+    append(Fmt("i") % "EI",  //
            {0b1111'1011});
   }
 
@@ -1797,9 +2099,10 @@ class Generator {
         0b010'11'110,
     };
     if (2 < m) {
-      throw std::out_of_range((boost::format("IM %d:out of range") % m).str());
+      char buf[32];
+      std::sprintf(buf, "IM %d:invalid argument", m);
     }
-    append(boost::format("IM %d") % static_cast<int>(m),  //
+    append(Fmt("i d") % "IM" % m,  //
            {0b1110'1101, code[m]});
   }
 
@@ -1808,38 +2111,38 @@ class Generator {
 
   /// IN A, (n) | A <- io[constant8]
   void in(const RegA& a, const IoAddr& n) {
-    append(boost::format("IN A, %s") % n.str,  //
+    append(Fmt("i r,I") % "IN" % a % n,  //
            {0b1101'1011, n.addr});
   }
 
   /// IN r, (C) | reg8 <- io[C]
   void in(const BasicReg8& r, const RegCAddr& c) {
-    append(boost::format("IN %s, (%s)") % r.str % c.m_reg.str,  //
+    append(Fmt("i r,r") % "IN" % r % c,  //
            {0b1110'1101, build(0b01, r, B)});
   }
 
   /// INI | mem[HL] <- io[C]; B <- B-1; HL <- HL+1;
   void ini(void) {
-    append(boost::format("INI"),  //
+    append(Fmt("i") % "INI",  //
            {0b1110'1101, 0b1010'0010});
   }
 
   /// INIR | while B!=0 { mem[HL] <- io[C]; B <- B-1; HL <- HL+1; }
   void inir(void) {
-    append(boost::format("INIR"),  //
+    append(Fmt("i") % "INIR",  //
            {0b1110'1101, 0b1011'0010});
   }
 
   /// IND | mem[HL] <- io[C]; B <- B-1; HL <- HL-1;
   void ind(void) {
-    append(boost::format("IND"),  //
+    append(Fmt("i") % "IND",  //
            {0b1110'1101, 0b1010'1010});
   }
 
   /// INDR | while B!=0 { mem[HL] <- io[C]; B <- B-1; HL <- HL-1; }
   void indr(void) {
-    append(boost::format("IND"),  //
-           {0b1110'1101, 0b1010'1010});
+    append(Fmt("i") % "INDR",  //
+           {0b1110'1101, 0b1011'1010});
   }
 
   // -------------------------------------------------------------------------
@@ -1847,37 +2150,37 @@ class Generator {
 
   /// OUT (n), A | io[constant8] <- A
   void out(const IoAddr& n, const RegA& a) {
-    append(boost::format("OUT %s, A") % n.str,  //
+    append(Fmt("i I,r") % "OUT" % n % a,  //
            {0b1101'0011, n.addr});
   }
 
   /// OUT (C), r | io[C] <- reg8
   void out(const RegCAddr& c, const BasicReg8& r) {
-    append(boost::format("OUT (%s), %s") % c.m_reg.str % r.str,  //
+    append(Fmt("i r,r") % "OUT" % c % r,  //
            {0b1110'1101, build(0b01, r, C)});
   }
 
   /// OUTI | io[C] <- mem[HL]; B <- B-1; HL <- HL+1;
   void outi(void) {
-    append(boost::format("OUTI"),  //
+    append(Fmt("i") % "OUTI",  //
            {0b1110'1101, 0b1010'0011});
   }
 
   /// OTIR | while B!=0 { io[C] <- mem[HL]; B <- B-1; HL <- HL+1; }
   void otir(void) {
-    append(boost::format("OTIR"),  //
+    append(Fmt("i") % "OTIR",  //
            {0b1110'1101, 0b1011'0011});
   }
 
   /// OUTD | io[C] <- mem[HL]; B <- B-1; HL <- HL-1;
   void outd(void) {
-    append(boost::format("OUTD"),  //
+    append(Fmt("i") % "OUTD",  //
            {0b1110'1101, 0b1010'1011});
   }
 
   /// OTDR | while B!=0 { io[C] <- mem[HL]; B <- B-1; HL <- HL-1; }
   void otdr(void) {
-    append(boost::format("OTDR"),  //
+    append(Fmt("i") % "OTDR",  //
            {0b1110'1101, 0b1011'1011});
   }
 
@@ -1886,19 +2189,19 @@ class Generator {
 
   /// DAA | Decimal Adjust Accumulator
   void daa(void) {
-    append(boost::format("DAA"),  //
+    append(Fmt("i") % "DAA",  //
            {0b0010'0111});
   }
 
   /// RLD | BCD left shift
   void rld(void) {
-    append(boost::format("RLD"),  //
+    append(Fmt("i") % "RLD",  //
            {0b1110'1101, 0b0110'1111});
   }
 
   /// RRD | BCD right shift
   void rrd(void) {
-    append(boost::format("RRD"),  //
+    append(Fmt("i") % "RRD",  //
            {0b1110'1101, 0b0110'0111});
   }
 };


### PR DESCRIPTION
boost::formatライブラリへの依存をやめた他、細かいバグの修正

* boost::formatライブラリへの依存をやめた
  * ニーモニック文字列組み立て用のフォーマッタを実装して差し替えた
  * その他使用箇所をC++の標準関数を使う形に変更
* 細かいバグ修正
  * 漏れていたテストパターンを追加
    * LD A,(0????h)
    * DB疑似命令の引数に文字列を渡すケース
  * テストコードの途中に仮で入れていたreturnが残っていたので除去
  * LD (IX or IY +d), n のコメントが誤っていたのを修正
  * INDR 命令のバイナリ生成が誤ってINDと同じになってたのを修正
* 発生させる例外のクラスが不適切な個所を修正
* メンバー変数を直接取得してuint8_tにキャストする処理が
   多数の箇所で行われていたので専用のメンバー関数を用意した
